### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -30,7 +30,11 @@ btnPrev.addEventListener('click', () => {
 for (let i = 0; i < btnGaleri.length; i++) {
   btnGaleri[i].addEventListener('click', (e) => {
     const galeriShow = document.querySelector('[data-galeri="show"]');
-    const indexBtn = e.target.getAttribute('data-galeri-index');
+    let indexBtn = parseInt(e.target.getAttribute('data-galeri-index'), 10);
+    if (isNaN(indexBtn) || indexBtn < 1 || indexBtn > 6) {
+      console.error('Invalid index:', indexBtn);
+      return;
+    }
     galeriShow.setAttribute('src', `public/img/Kartini ${indexBtn}.png`);
     galeriShow.setAttribute('data-index-show', indexBtn);
     for (let i = 0; i < btnGaleri.length; i++) {


### PR DESCRIPTION
Potential fix for [https://github.com/kdandy/Kartini/security/code-scanning/1](https://github.com/kdandy/Kartini/security/code-scanning/1)

To fix the problem, we need to ensure that the value of `indexBtn` is sanitized before it is used in the template literal. Since `indexBtn` is expected to be a numeric value, we can validate and sanitize it by converting it to an integer. This will prevent any malicious input from being interpreted as HTML.

- Convert the `indexBtn` value to an integer using `parseInt` and ensure it is a valid number.
- If the value is not a valid number, handle the error appropriately (e.g., by setting a default value or ignoring the input).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
